### PR TITLE
Remove jekyll_ai_related_posts gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'minima', '~> 2.5', '>= 2.5.2'
 # If you have any plugins, put them here!
 group :jekyll_plugins do
 
-gem 'jekyll_ai_related_posts', '~> 0.1.4'
 gem 'jekyll-avatar', '~> 0.8.0'
 gem 'jekyll-default-layout', '~> 0.1.5'
 gem 'jekyll-feed', '~> 0.17.0'


### PR DESCRIPTION
Removed jekyll_ai_related_posts gem from jekyll_plugins group. Only works on blog posts.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [ ] New blog post 
- [ ] Bugfix
- [ ] Jekyll change(s)
- [ ] Liquid change(s)
- [ ] Markdown change(s)
- [ ] YAML change(s)
- [ ] Build error(s)
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Language 

- [ ] awk
- [ ] C/C++/C#
- [ ] Ruby
- [ ] Python 

## Files added

- 

## Files modified 

- 

## Files deleted 

- 

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change -->